### PR TITLE
publish `stale_maccarone` for self-hosting

### DIFF
--- a/.github/workflows/publish-to-pypi-stale.yml
+++ b/.github/workflows/publish-to-pypi-stale.yml
@@ -1,0 +1,30 @@
+name: PyPI
+on:
+  release:
+    types: [published]
+jobs:
+  publish-to-pypi:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --upgrade pip
+      - name: Rename to `stale_maccarone`
+        run: |
+          support/rename_to_stale.sh
+      - name: Build package
+        run: |
+          pip install build
+          python -m build
+      - name: Publish package
+        run: |
+          pip install twine
+          twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi-stale.yml
+++ b/.github/workflows/publish-to-pypi-stale.yml
@@ -27,4 +27,4 @@ jobs:
           twine upload dist/*
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN_STALE_MACCARONE }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,4 @@ dev = [
 maccarone = "maccarone.scripts.preprocess:script_main"
 
 [tool.setuptools_scm]
+local_scheme = "node-and-date"

--- a/support/rename_to_stale.sh
+++ b/support/rename_to_stale.sh
@@ -1,8 +1,11 @@
 #!/bin/env bash
 
+# hackishly rewrite the project to use a different name (to support self-hosting)
+
 set -eux
 
 find ./src/maccarone -name "*.py" -print0 | xargs -0 sed -i 's/import maccarone/import stale_maccarone/'
 find ./src/maccarone -name "*.py" -print0 | xargs -0 sed -i 's/from maccarone/from stale_maccarone/'
 
 sed -i 's/name = "maccarone"/name = "stale_maccarone"/' pyproject.toml
+sed -i 's/local_scheme = "node-and-date"/local_scheme = "no-local-version"/' pyproject.toml

--- a/support/rename_to_stale.sh
+++ b/support/rename_to_stale.sh
@@ -1,0 +1,8 @@
+#!/bin/env bash
+
+set -eux
+
+find ./src/maccarone -name "*.py" -print0 | xargs -0 sed -i 's/import maccarone/import stale_maccarone/'
+find ./src/maccarone -name "*.py" -print0 | xargs -0 sed -i 's/from maccarone/from stale_maccarone/'
+
+sed -i 's/name = "maccarone"/name = "stale_maccarone"/' pyproject.toml


### PR DESCRIPTION
To support self-hosting we want to publish the package under `stale_maccarone`, which requires renaming imports etc. This PR implements a crude way to do that.