### PR TITLE
block-specific preprocessing via `--block-at-line`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "src"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/src/maccarone/preprocessor.py
+++ b/src/maccarone/preprocessor.py
@@ -7,6 +7,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
 )
 
 from parsimonious.nodes import (
@@ -33,6 +34,34 @@ class MissingPiece(Piece):
     indent: str
     guidance: str
     inlined: Optional[str] = None
+    enabled: bool = True
+
+    def get_line_pos(self, raw_source: str) -> Tuple[int, int]:
+        start_line = raw_source.count('\n', 0, self.start) + 1
+        end_line = raw_source.count('\n', 0, self.end) + 1
+
+        return (start_line, end_line)
+
+    def complete(self, replacement: Optional[str]) -> str:
+        (indent, guidance) = (self.indent, self.guidance)
+
+        if "\n" in guidance:
+            guidance_lines = "\n"
+            guidance_lines += "\n".join(f"{indent}#{line}" for line in guidance.splitlines())
+            guidance_lines += f"\n{indent}#"
+        else:
+            guidance_lines = guidance
+
+        source = f"{indent}#<<{guidance_lines}>>\n"
+
+        if replacement is not None:
+            source += indent + indent.join(replacement.splitlines(True))
+            source += f"{indent}#<</>>\n"
+        elif self.inlined is not None:
+            source += self.inlined
+            source += f"{indent}#<</>>\n"
+
+        return source
 
 grammar = Grammar(
     r"""
@@ -79,6 +108,10 @@ def find_line_number(text: str, pos: int):
     #<</>>
 
 class RawSourceVisitor(NodeVisitor):
+    def __init__(self, raw_source: str, block_at_line: Optional[int] = None):
+        self._raw_source = raw_source
+        self._block_at_line = block_at_line
+
     def generic_visit(self, node: Node, visited_children: List[Node]):
         return visited_children or node
 
@@ -100,6 +133,13 @@ class RawSourceVisitor(NodeVisitor):
     def visit_snippet(self, node: Node, visited_children: list):
         (snippet_open, quantified_source) = visited_children
 
+        if self._block_at_line is None:
+            enabled = True
+        else:
+            start_line = find_line_number(self._raw_source, node.start)
+            end_line = find_line_number(self._raw_source, node.end)
+            enabled = start_line <= self._block_at_line <= end_line
+
         if isinstance(quantified_source, list):
             ((source, _),) = quantified_source
         else:
@@ -111,6 +151,7 @@ class RawSourceVisitor(NodeVisitor):
             end=node.end,
             indent=snippet_open.indent,
             guidance=snippet_open.guidance,
+            enabled=enabled,
             inlined=source,
         )
         #<</>>
@@ -164,9 +205,9 @@ class RawSourceVisitor(NodeVisitor):
     def visit_ai_source(self, node: Node, visited_children: list):
         return node.text
 
-def raw_source_to_pieces(input: str) -> List[Piece]:
+def raw_source_to_pieces(input: str, block_at_line: Optional[int] = None) -> List[Piece]:
     tree = grammar.parse(input)
-    visitor = RawSourceVisitor()
+    visitor = RawSourceVisitor(input, block_at_line)
     pieces = visitor.visit(tree)
 
     return pieces
@@ -179,8 +220,16 @@ def raw_pieces_to_tagged_input(raw_pieces: List[Piece]) -> str:
         if isinstance(piece, PresentPiece):
             tag_source += piece.text
         elif isinstance(piece, MissingPiece):
-            tag_source += f'# <write_this id="{id}">\n{piece.indent}# {piece.guidance}\n{piece.indent}# </>'
-            id += 1
+            if piece.enabled:
+                tag_source += f'# <write_this id="{id}">\n{piece.indent}# {piece.guidance}\n{piece.indent}# </>'
+                id += 1
+            else:
+                tag_source += f"{piece.indent}# {piece.guidance}\n"
+
+                if piece.inlined is None:
+                    tag_source += f"{piece.indent}# (WIP)"
+                else:
+                    tag_source += f"{piece.inlined}"
         else:
             raise TypeError("unknown piece type", piece)
 
@@ -249,20 +298,11 @@ def pieces_to_final_source(
         if isinstance(raw, PresentPiece):
             final_source += raw.text
         elif isinstance(raw, MissingPiece):
-            (indent, guidance) = raw.indent, raw.guidance
-
-            if "\n" in guidance:
-                guidance_lines = "\n"
-                guidance_lines += "\n".join(f"{indent}#{line}" for line in guidance.splitlines())
-                guidance_lines += f"\n{indent}#"
+            if raw.enabled:
+                final_source += raw.complete(completed_pieces[id])
+                id += 1
             else:
-                guidance_lines = guidance
-
-            final_source += f"{indent}#<<{guidance_lines}>>\n"
-            completed = completed_pieces[id]
-            final_source += indent + indent.join(completed.splitlines(True))
-            final_source += f"{indent}#<</>>\n"
-            id += 1
+                final_source += raw.complete(None)
         else:
             raise TypeError("unknown piece type", raw)
 
@@ -273,8 +313,9 @@ def pieces_to_final_source(
 def preprocess_maccarone(
         raw_source: str,
         chat_api: ChatAPI,
+        block_at_line: Optional[int] = None,
     ) -> str:
-    raw_pieces = raw_source_to_pieces(raw_source)
+    raw_pieces = raw_source_to_pieces(raw_source, block_at_line)
     tagged_input = raw_pieces_to_tagged_input(raw_pieces)
     tagged_output = tagged_input_to_tagged_output(tagged_input, chat_api)
     completed_pieces = tagged_output_to_completed_pieces(tagged_output)

--- a/src/maccarone/preprocessor.py
+++ b/src/maccarone/preprocessor.py
@@ -73,6 +73,11 @@ class SnippetOpen:
     indent: str
     guidance: str
 
+def find_line_number(text: str, pos: int):
+    #<<find the line number of the given char position>>
+    return text.count('\n', 0, pos) + 1
+    #<</>>
+
 class RawSourceVisitor(NodeVisitor):
     def generic_visit(self, node: Node, visited_children: List[Node]):
         return visited_children or node

--- a/src/maccarone/scripts/preprocess.py
+++ b/src/maccarone/scripts/preprocess.py
@@ -4,6 +4,7 @@ import glob
 import logging
 
 from argparse import Namespace
+from typing import Optional
 
 from maccarone.openai import ChatAPI
 from maccarone.preprocessor import preprocess_maccarone
@@ -14,6 +15,7 @@ def preprocess(
         mn_path: str,
         print_: bool,
         rewrite: bool,
+        block_at_line: Optional[int],
     ) -> None:
     # produce Python source
     logger.info("preprocessing %s", mn_path)
@@ -25,7 +27,7 @@ def preprocess(
         mn_source = file.read()
     #<</>>
 
-    py_source = preprocess_maccarone(mn_source, chat_api)
+    py_source = preprocess_maccarone(mn_source, chat_api, block_at_line=block_at_line)
 
     if rewrite:
         #<<write py_source to py_path>>
@@ -37,7 +39,7 @@ def preprocess(
     if print_:
         print(py_source, end="")
 
-def main(path: str, print_: bool, rewrite: bool, suffix: str) -> None:
+def main(path: str, print_: bool, rewrite: bool, suffix: str, block_at_line: Optional[int] = None) -> None:
     """Preprocess files with Maccarone snippets."""
 
     if os.path.isdir(path):
@@ -50,7 +52,7 @@ def main(path: str, print_: bool, rewrite: bool, suffix: str) -> None:
 
     #<<preprocess mn_files>>
     for mn_file in mn_files:
-        preprocess(mn_file, print_, rewrite)
+        preprocess(mn_file, print_, rewrite, block_at_line)
     #<</>>
 
 def parse_args() -> Namespace:
@@ -65,6 +67,7 @@ def parse_args() -> Namespace:
     parser.add_argument("--print", dest="print_", action="store_true", help="Print the preprocessed source code")
     parser.add_argument("--rewrite", action="store_true", help="Rewrite the source file with the preprocessed code")
     parser.add_argument("--suffix", default=".py", help="Suffix for the preprocessed files")
+    parser.add_argument("--block-at-line", type=int, help="Preprocess only the block at given line")
     args = parser.parse_args()
     return args
     #<</>>

--- a/src/maccarone/test/test_preprocessor.py
+++ b/src/maccarone/test/test_preprocessor.py
@@ -11,11 +11,17 @@ from maccarone.preprocessor import (
     tagged_output_to_completed_pieces,
 )
 
+LB = "<"
+RB = ">"
+LL = "<<" # hide test content from maccarone itself
+RR = ">>"
+CLOSE = f"#{LL}/{RR}"
+
 @pytest.mark.parametrize("input, expected", [
     (
-        """
+        f"""
         this source has
-        #<<a missing piece>>
+        #{LL}a missing piece{RR}
         above
         """,
         [
@@ -25,11 +31,11 @@ from maccarone.preprocessor import (
         ],
     ),
     (
-        """
+        f"""
         this source has
-        #<<a missing piece>>
+        #{LL}a missing piece{RR}
         with inline source
-        #<</>>
+        {CLOSE}
         above
         """,
         [
@@ -39,14 +45,14 @@ from maccarone.preprocessor import (
         ],
     ),
     (
-        """
+        f"""
         this source has
-        #<<
+        #{LL}
         # a missing piece
         # with multiline guidance
-        #>>
+        #{RR}
         and inline source
-        #<</>>
+        {CLOSE}
         above
         """,
         [
@@ -62,11 +68,11 @@ from maccarone.preprocessor import (
         ],
     ),
     (
-        """
+        f"""
         this source has...*
-        #<<various special chars, (like this)>>
+        #{LL}various special chars, (like this){RR}
         and inline source with more chars _-%$
-        #<</>>
+        {CLOSE}
         `and more!`
         """,
         [
@@ -95,13 +101,13 @@ def test_raw_source_to_pieces(input, expected):
             MissingPiece(0, 0, "", "add two numbers from command line args, using argparse"),
             PresentPiece(0, 0, "\n"),
         ],
-        dedent("""
+        dedent(f"""
         def add_two_numbers(x, y):
-            # <write_this id="0">
+            # {LB}write_this id="0"{RB}
             # add the args
             # </>
         
-        # <write_this id="1">
+        # {LB}write_this id="1"{RB}
         # add two numbers from command line args, using argparse
         # </>
         """),
@@ -112,15 +118,15 @@ def test_raw_source_to_tagged_input(raw_pieces, expected):
 
 @pytest.mark.parametrize("tagged, expected", [
     (
-        '<completed id="0">\ndef add_two_numbers(x, y):\n    return x + y\n</>\n',
+        f'{LB}completed id="0"{RB}\ndef add_two_numbers(x, y):\n    return x + y\n</>\n',
         {0: 'def add_two_numbers(x, y):\n    return x + y\n'}
     ),
     (
-        '<completed id="1">\ndef subtract_two_numbers(x, y):\n    return x - y\n</>\n',
+        f'{LB}completed id="1"{RB}\ndef subtract_two_numbers(x, y):\n    return x - y\n</>\n',
         {1: 'def subtract_two_numbers(x, y):\n    return x - y\n'}
     ),
     (
-        '<completed id="1">\nfoo\n</>\n<completed id="2">\ndef multiply_two_numbers(x, y):\n    return x * y\n</>\n',
+        f'{LB}completed id="1"{RB}\nfoo\n</>\n{LB}completed id="2"{RB}\ndef multiply_two_numbers(x, y):\n    return x * y\n</>\n',
         {
             1: "foo\n",
             2: 'def multiply_two_numbers(x, y):\n    return x * y\n'

--- a/src/maccarone/test/test_preprocessor.py
+++ b/src/maccarone/test/test_preprocessor.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 from maccarone.preprocessor import (
     PresentPiece,
     MissingPiece,
+    find_line_number,
     raw_source_to_pieces,
     raw_pieces_to_tagged_input,
     tagged_output_to_completed_pieces,
@@ -128,3 +129,19 @@ def test_raw_source_to_tagged_input(raw_pieces, expected):
 ])
 def test_tagged_output_to_completed_pieces(tagged, expected):
     assert tagged_output_to_completed_pieces(tagged) == expected
+
+#<<test find_line_number(text, pos); pos is 0-indexed>>
+@pytest.mark.parametrize("text, pos, expected", [
+    ("hello\nworld", 0, 1),
+    ("hello\nworld", 5, 1),
+    ("hello\nworld", 6, 2),
+    ("hello\nworld", 11, 2),
+    ("\nhello\nworld", 0, 1),
+    ("\nhello\nworld", 1, 2),
+    ("\nhello\nworld", 6, 2),
+    ("\nhello\nworld", 7, 3),
+    ("\nhello\nworld", 12, 3),
+])
+def test_find_line_number(text, pos, expected):
+    assert find_line_number(text, pos) == expected
+#<</>>


### PR DESCRIPTION
```python
def add_two_numbers(x, y):
    #<<add both args>>

#<<argparse then print result>>
```

 ↓

```bash
maccarone examples/add.py --print --block-at-line=2
```

 ↓

```python
def add_two_numbers(x, y):
    #<<add both args>>
    return x + y
    #<</>>

#<<argparse then print result>>
```